### PR TITLE
Add helper function appendSite in class TwigExtension.

### DIFF
--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -47,6 +47,7 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('urlFor', array($this, 'urlFor')),
             new \Twig_SimpleFunction('baseUrl', array($this, 'base')),
             new \Twig_SimpleFunction('siteUrl', array($this, 'site')),
+            new \Twig_SimpleFunction('appendSiteUrl', array($this, 'appendSite'))
         );
     }
 
@@ -58,6 +59,13 @@ class TwigExtension extends \Twig_Extension
     public function site($url, $withUri = true, $appName = 'default')
     {
         return $this->base($withUri, $appName) . '/' . ltrim($url, '/');
+    }
+
+    public function appendSite($url, $append)
+    {
+        $siteUrl = $this->site($url, $withUri = true, $appName = 'default');
+        $forwardSlash = strcmp(substr($siteUrl, -1), '/') ? '/' : '';       
+        return $siteUrl . $forwardSlash . $append;
     }
 
     public function base($withUri = true, $appName = 'default')


### PR DESCRIPTION
Hi there!
I wrote a helper function called appendSiteUrl for the TwigExtension class.
The function is used to append parameters to the site url.
I thought this function might be useful.

Example usage:

{{ appendSiteUrl('/posts', 10)}}    => .. /posts/10
{{ appendSiteUrl('/posts/', 10)}}   => .. /posts/10

Cheers,
Alexander
