### PR TITLE
getData instead of all

### DIFF
--- a/Smarty.php
+++ b/Smarty.php
@@ -84,7 +84,7 @@ class Smarty extends \Slim\View
     public function render($template)
     {
         $parser = $this->getInstance();
-        $parser->assign($this->all());
+        $parser->assign($this->getData());
 
         return $parser->fetch($template);
     }


### PR DESCRIPTION
I do not find any function all in the slim code base and it seems getData works while all is not.

let me know if it's a wrong patch. (Twig seems using all() too)

Thanks
