### PR TITLE
Add Twig's dump() function (fixes [part of] #10)

### DIFF
--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -74,6 +74,10 @@ class TwigExtension extends \Twig_Extension
     
     public function dump($var, $appName = 'default')
     {
-        return var_dump($var);
+        if (Slim::getInstance($appName)->view()->parserOptions['debug']) {
+            return var_dump($var);
+        } else {
+            return;
+        }
     }
 }

--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -47,6 +47,7 @@ class TwigExtension extends \Twig_Extension
             new \Twig_SimpleFunction('urlFor', array($this, 'urlFor')),
             new \Twig_SimpleFunction('baseUrl', array($this, 'base')),
             new \Twig_SimpleFunction('siteUrl', array($this, 'site')),
+            new \Twig_SimpleFunction('dump', array($this, 'dump')),
         );
     }
 
@@ -69,5 +70,10 @@ class TwigExtension extends \Twig_Extension
             $uri .= $req->getRootUri();
         }
         return $uri;
+    }
+    
+    public function dump($var, $appName = 'default')
+    {
+        return var_dump($var);
     }
 }


### PR DESCRIPTION
Added a function to the bottom of TwigExtension.php to emulate Twig's [`dump()`](http://twig.sensiolabs.org/doc/functions/dump.html) function
