### PR TITLE
Fix declaration incompatibility with Slim\View

### DIFF
--- a/Smarty.php
+++ b/Smarty.php
@@ -81,7 +81,7 @@ class Smarty extends \Slim\View
      * @param    string $template The path to the template, relative to the  templates directory.
      * @return   void
      */
-    public function render($template)
+    public function render($template, $data = null)
     {
         $parser = $this->getInstance();
         $parser->assign($this->all());

--- a/Twig.php
+++ b/Twig.php
@@ -85,7 +85,7 @@ class Twig extends \Slim\View
         $env = $this->getInstance();
         $parser = $env->loadTemplate($template);
 
-        return $parser->render($this->all());
+        return $parser->render($this->all(), $data);
     }
 
     /**

--- a/Twig.php
+++ b/Twig.php
@@ -80,7 +80,7 @@ class Twig extends \Slim\View
      * @param   string $template The path to the Twig template, relative to the Twig templates directory.
      * @return  void
      */
-    public function render($template)
+    public function render($template, $data = null)
     {
         $env = $this->getInstance();
         $parser = $env->loadTemplate($template);


### PR DESCRIPTION
After this commit the `Slim\Views\Twig::render()` declaration is not compatible with the `Slim\View::render()`

https://github.com/codeguy/Slim/commit/8e3b1fcc303eb9964c08a62404bc415ccb1189a6 

`Strict Standards: Declaration of Slim\Views\Twig::render() should be compatible with 
Slim\View::render($template, $data = NULL) in /app/vendor/slim/views/Slim/Views/Twig.php on line 46`
