### PR TITLE
Fix "Declaration of Slim\Views\Twig::render() should be compatible..."

### DIFF
--- a/Twig.php
+++ b/Twig.php
@@ -80,12 +80,12 @@ class Twig extends \Slim\View
      * @param   string $template The path to the Twig template, relative to the Twig templates directory.
      * @return  void
      */
-    public function render($template)
+    public function render($template, $data = null)
     {
         $env = $this->getInstance();
         $parser = $env->loadTemplate($template);
 
-        return $parser->render($this->all());
+        return $parser->render($this->all(), $data);
     }
 
     /**


### PR DESCRIPTION
After codeguy/Slim@8e3b1fcc303eb9964c08a62404bc415ccb1189a6, the signature of `Slim\View::render()` changed, so the Twig view should change too.

For reference this is the error that it's throwing right now:

```
PHP Strict Standards:  Declaration of Slim\Views\Twig::render() should be compatible with Slim\View::render($template, $data = NULL) in .../Slim/Views/Twig.php on line 46
```
