### PR TITLE
Fixed Twig view render method not using the data argument correctly.

### DIFF
--- a/Twig.php
+++ b/Twig.php
@@ -86,7 +86,9 @@ class Twig extends \Slim\View
         $env = $this->getInstance();
         $parser = $env->loadTemplate($template);
 
-        return $parser->render($this->all(), $data);
+        $data = array_merge($this->all(), (array) $data);
+
+        return $parser->render($data);
     }
 
     /**


### PR DESCRIPTION
The view data passed as argument to the render method of Twig view was never used correctly.
