### PR TITLE
fix for wrong return type hint

### DIFF
--- a/Twig.php
+++ b/Twig.php
@@ -79,7 +79,7 @@ class Twig extends \Slim\View
      *
      * @param   string $template The path to the Twig template, relative to the Twig templates directory.
      * @param null $data
-     * @return  void
+     * @return  string
      */
     public function render($template, $data = null)
     {


### PR DESCRIPTION
noticed with phpstorm hints that there is wrong return type specified for Twig render method, it actually return string rather than void

this is just to get rid of notices from ide

thnx
