### PR TITLE
Pass data to Twig template correctly

### DIFF
--- a/Twig.php
+++ b/Twig.php
@@ -86,7 +86,9 @@ class Twig extends \Slim\View
         $env = $this->getInstance();
         $parser = $env->loadTemplate($template);
 
-        return $parser->render($this->all(), $data);
+        $data = array_merge($this->all(), $data);
+
+        return $parser->render($data);
     }
 
     /**


### PR DESCRIPTION
Calling `$app->view->render('template.twig', [ 'x' => 'y' ]);` calls `$parser->render( $this->all(), $data )`, but the `Twig_Template` method only takes a single parameter. This causes parameters passed into the method to be ignored.

Attached PR does an `array_merge` on the data first.
