### PR TITLE
Support array-based options argument for Smarty function {urlFor}

### DIFF
--- a/SmartyPlugins/function.urlFor.php
+++ b/SmartyPlugins/function.urlFor.php
@@ -19,10 +19,21 @@ function smarty_function_urlFor($params, $template)
 
 	if (isset($params['options']))
 	{
-		$options = explode('|', $params['options']);
-		foreach ($options as $option) {
-			list($key, $value) = explode('.', $option);
-			$opts[$key] = $value;
+		switch (gettype($params['options'])) {
+			case 'array':
+				$opts = $params['options'];
+				break;
+
+			case 'string':
+				$options = explode('|', $params['options']);
+				foreach ($options as $option) {
+					list($key, $value) = explode('.', $option);
+					$opts[$key] = $value;
+				}
+				break;
+
+			default:
+				throw new \Exception('Options parameter is of unknown type, provide either string or array');
 		}
 
 		$url = \Slim\Slim::getInstance($appName)->urlFor($name, $opts);


### PR DESCRIPTION
Smarty supports native PHP arrays as arguments for functions. I think the syntax in templates is much cleaner than the current 'dot'-solution. This PR is backwards compatible.

Example usages:

```
{urlFor name="foo" options=["key" => "value"]}
{urlFor name="foo" options=["key" => $value]}
{urlFor name="foo" options=$options}
```
