### PR TITLE
Allow the Twig instance to be set externally.

### DIFF
--- a/Twig.php
+++ b/Twig.php
@@ -132,6 +132,20 @@ class Twig extends \Slim\View
 
         return $this->parserInstance;
     }
+    
+    /**
+     * Sets the TwigEnvironment to a new value. Useful for building your own
+     * instance of TwigEnvironment or for wrapping an existing instance with
+     * a decorator.
+     * 
+     * @return self
+     */
+    public function setInstance(\Twig_Environment $environment)
+    {
+        $this->parserInstance = $environment;
+        
+        return $this;
+    }
 
     /**
      * DEPRECATION WARNING! This method will be removed in the next major point release


### PR DESCRIPTION
This is the change that I was trying to subclass this class to make. Specifically, I need this to be able to wrap the Twig environment with a data collector for the PHP DebugBar. Regardless, this change lets other people either create their own instances of Twig or use the existing functions in this class to fetch the current one and wrap it in a decorator.
