### PR TITLE
Replace Slim\Http\Request::getRootUri() calls to getScriptName()

### DIFF
--- a/SmartyPlugins/function.baseUrl.php
+++ b/SmartyPlugins/function.baseUrl.php
@@ -19,7 +19,7 @@ function smarty_function_baseUrl($params, $template)
     $uri = $req->getUrl();
 
     if ($withUri) {
-        $uri .= $req->getRootUri();
+        $uri .= $req->getScriptName();
     }
 
     return $uri;

--- a/SmartyPlugins/function.siteUrl.php
+++ b/SmartyPlugins/function.siteUrl.php
@@ -20,7 +20,7 @@ function smarty_function_siteUrl($params, $template)
     $uri = $req->getUrl();
 
     if ($withUri) {
-        $uri .= $req->getRootUri();
+        $uri .= $req->getScriptName();
     }
 
     return $uri . '/' . ltrim($url, '/');

--- a/TwigExtension.php
+++ b/TwigExtension.php
@@ -67,7 +67,7 @@ class TwigExtension extends \Twig_Extension
         $uri = $req->getUrl();
 
         if ($withUri) {
-            $uri .= $req->getRootUri();
+            $uri .= $req->getScriptName();
         }
         return $uri;
     }


### PR DESCRIPTION
The original method is an alias since Slim 2.4.0.
