### PR TITLE
Catches error thrown from Twig v 1.21 and newer

### DIFF
--- a/Twig.php
+++ b/Twig.php
@@ -113,11 +113,16 @@ class Twig extends \Slim\View
              * Check if Twig_Autoloader class exists
              * otherwise include it.
              */
-            if (!class_exists('\Twig_Autoloader')) {
-                require_once $this->parserDirectory . '/Autoloader.php';
-            }
+            try {
+                if (!class_exists('\Twig_Autoloader')) {
+                    require_once $this->parserDirectory . '/Autoloader.php';
+                }
 
-            \Twig_Autoloader::register();
+                \Twig_Autoloader::register();
+            } catch (\ErrorException $e) {
+                $app = \Slim\Slim::getInstance();
+                $app->log->error($e->getMessage());
+            }
             $loader = new \Twig_Loader_Filesystem($this->getTemplateDirs());
             $this->parserInstance = new \Twig_Environment(
                 $loader,


### PR DESCRIPTION
Since Twig 1.21 (https://github.com/twigphp/Twig/commit/cc980282dee1964d867b70666ec7d2183d87ea4c) using Twig_Loaders is deprecated, and triggers a silent error using @ supressor. However, certain middlewares such as Whoops will still stop the normal flow.

This PR wraps the Twig_Loader usage in a try/catch block, silently sending an eventual error to Slim's log. If the user's dependency has a Twig version prior to 1.21, it behaves just as usual.
